### PR TITLE
Fix sources.list when upgrading from old versions

### DIFF
--- a/content/upgrade-pop.md
+++ b/content/upgrade-pop.md
@@ -169,7 +169,8 @@ These older Pop!\_OS releases are now unsupported and no new updates are availab
 
 ```bash
 # change server from us.archive to old-releases
-sudo sed -i 's/us.archive/old-releases/g' /etc/apt/sources.list
+sudo sed -i 's/us.archive/old-releases/g' /etc/apt/sources.list.d/system.sources
+# Use `sudo sed -i 's/us.archive/old-releases/g' /etc/apt/sources.list` when updating pre 21.04
 # request release files
 sudo apt update -m
 # configure any packages partially setup


### PR DESCRIPTION
In the section `Upgrading older releases` the `Get your current system fully updated` assumed that the version being used contains all sources in `/etc/apt/sources.list`. Since 21.04 this isn't the case as they are now stored in `/etc/apt/sources.list/*`.

This change will change the default line to use the new location and mention in a comment the  old location as well.